### PR TITLE
fix: multisig sort not consistent with axon's overlord

### DIFF
--- a/axon-tools/src/types.rs
+++ b/axon-tools/src/types.rs
@@ -564,13 +564,13 @@ pub struct ValidatorExtend {
 
 impl PartialOrd for ValidatorExtend {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.bls_pub_key.cmp(&other.bls_pub_key))
+        Some(self.cmp(&other))
     }
 }
 
 impl Ord for ValidatorExtend {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.bls_pub_key.cmp(&other.bls_pub_key)
+        self.pub_key.as_bytes().cmp(&other.pub_key.as_bytes())
     }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR sort validator's based on pub_key, which is in consistent with axon's overlord.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

